### PR TITLE
Auto-approve call types

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -2,17 +2,20 @@ class Classification < ApplicationRecord
   has_paper_trail
 
   CALL_TYPE = "Detailed Call Type".freeze
+  LOW_CONFIDENCE = "Low Confidence".freeze
+  SOMEWHAT_CONFIDENT = "Somewhat Confident".freeze
+  VERY_CONFIDENT = "Very Confident".freeze
 
   belongs_to :common_incident_type, optional: true
   belongs_to :user, optional: true
   belongs_to :unique_value, optional: true, counter_cache: true
 
-  after_save :update_data_set_completion
+  after_save :update_data_set_completion_and_approval_status
 
   enum :confidence_rating, {
-    "Low Confidence" => 0,
-    "Somewhat Confident" => 1,
-    "Very Confident" => 2,
+    LOW_CONFIDENCE => 0,
+    SOMEWHAT_CONFIDENT => 1,
+    VERY_CONFIDENT => 2,
   }
 
   validates :user, :unique_value, :common_type, :value,
@@ -25,9 +28,12 @@ class Classification < ApplicationRecord
 
   private
 
-  def update_data_set_completion
+  def update_data_set_completion_and_approval_status
     return true unless unique_value
 
     unique_value.field.data_set.update_completion
+    unique_value.update_approval_status
+
+    true
   end
 end

--- a/db/migrate/20220820025525_add_approval_details_to_unique_values.rb
+++ b/db/migrate/20220820025525_add_approval_details_to_unique_values.rb
@@ -1,0 +1,7 @@
+class AddApprovalDetailsToUniqueValues < ActiveRecord::Migration[7.0]
+  def change
+    add_column :unique_values, :approved_at, :datetime
+    add_column :unique_values, :review_required, :boolean, default: false
+    add_column :unique_values, :auto_reviewed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_093937) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_20_025525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -126,6 +126,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_093937) do
     t.string "value"
     t.integer "frequency"
     t.integer "classifications_count", default: 0
+    t.datetime "approved_at"
+    t.boolean "review_required", default: false
+    t.datetime "auto_reviewed_at"
     t.index ["field_id"], name: "index_unique_values_on_field_id"
   end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Classification, type: :model do
       context "with associated unique_value" do
         it "calls update_completion on the related data_set" do
           expect_any_instance_of(DataSet).to receive(:update_completion)
+          expect_any_instance_of(UniqueValue).to receive(:update_approval_status)
           classification = build(:classification)
           classification.save
         end
@@ -40,6 +41,7 @@ RSpec.describe Classification, type: :model do
       context "without associated unique_value" do
         it "does nothing" do
           expect_any_instance_of(DataSet).not_to receive(:update_completion)
+          expect_any_instance_of(UniqueValue).not_to receive(:update_approval_status)
           classification = build(:classification, unique_value: nil)
           classification.save
         end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
## Overview

Add logic to auto-approve a `call_type` unique value if it meets the following criteria:

- A call type has been classified 3 times
- All 3 classifications indicate the same common incident type
- The confidence level of all are "somewhat confident" or above.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #11

## Changes

- Added approval status check to the classification `after_save` callback
- Set `approved_at` to the current timestamp if auto-approval goes through
- Set `review_required: true` and `auto_reviewed_at: current time` if criteria are not met
- Wrote tests for all cases 
- Added ActiveSupport `TimeHelpers` to help with the timestamp expectations