### PR TITLE
Redirect to classifications from dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -3,7 +3,7 @@ class DashboardsController < ApplicationController
 
   def index
     authorize! :index, :dashboard
-    @call_type_maps = Classification.all.order(:value).includes(:common_incident_type)
+    redirect_to call_types_classifications_path
   end
 
   def show

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -28,24 +28,28 @@ class Role < ApplicationRecord
       all: [:all],
     },
     volunteer: {
+      classifications: [:index],
       dashboard: [:index, :show],
       data_sets: [:index, :show],
     },
     data_importer: {
+      classifications: [:index],
       dashboard: [:index, :show],
       data_sets: [:index, :show, :create, :update],
     },
     data_classifier: {
-      dashboard: [:index, :show],
-      common_incident_types: [:index],
-      classifications: [:index, :create],
       categories: [:request],
+      classifications: [:index, :create],
+      common_incident_types: [:index],
+      dashboard: [:index, :show],
     },
     data_consumer: {
+      classifications: [:index],
       dashboard: [:index, :show],
       data_sets: [:export],
     },
     data_reviewer: {
+      classifications: [:index],
       dashboard: [:index, :show],
       data_categorization: [:review],
     },

--- a/app/views/classifications/_data_set_card.html.erb
+++ b/app/views/classifications/_data_set_card.html.erb
@@ -1,4 +1,4 @@
- <% if data_set.completed? %>
+ <% if data_set.completed? || !authorized?(:create, :classifications) %>
   <%= render "data_set_card_content", data_set: data_set %>
 <% else %>
   <%= link_to classify_data_sets_call_types_classifications_path(data_set.id) do %>

--- a/app/views/classifications/_data_set_card_content.html.erb
+++ b/app/views/classifications/_data_set_card_content.html.erb
@@ -8,7 +8,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
-    <% else %>
+    <% elsif authorized?(:create, :classifications) %>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor">
         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd" />
       </svg>

--- a/spec/requests/classifications_spec.rb
+++ b/spec/requests/classifications_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe "Classifications", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_consumer
-      include_examples "unauthorized", :get, :data_reviewer
-      include_examples "unauthorized", :get, :volunteer
-      include_examples "unauthorized", :get, :data_importer
-
+      include_examples "authorized", :get, :data_consumer, :found
+      include_examples "authorized", :get, :data_reviewer, :found
+      include_examples "authorized", :get, :volunteer, :found
+      include_examples "authorized", :get, :data_importer, :found
       include_examples "authorized", :get, :data_admin, :found
       include_examples "authorized", :get, :data_classifier, :found
 
@@ -37,11 +36,10 @@ RSpec.describe "Classifications", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_consumer
-      include_examples "unauthorized", :get, :data_reviewer
-      include_examples "unauthorized", :get, :volunteer
-      include_examples "unauthorized", :get, :data_importer
-
+      include_examples "authorized", :get, :data_consumer
+      include_examples "authorized", :get, :data_reviewer
+      include_examples "authorized", :get, :volunteer
+      include_examples "authorized", :get, :data_importer
       include_examples "authorized", :get, :data_admin
       include_examples "authorized", :get, :data_classifier
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Dashboards", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "authorized", :get, :data_admin
-      include_examples "authorized", :get, :volunteer
-      include_examples "authorized", :get, :data_importer
-      include_examples "authorized", :get, :data_classifier
-      include_examples "authorized", :get, :data_consumer
-      include_examples "authorized", :get, :data_reviewer
+      include_examples "authorized", :get, :data_admin, :found
+      include_examples "authorized", :get, :volunteer, :found
+      include_examples "authorized", :get, :data_importer, :found
+      include_examples "authorized", :get, :data_classifier, :found
+      include_examples "authorized", :get, :data_consumer, :found
+      include_examples "authorized", :get, :data_reviewer, :found
 
       context "when authorized" do
         let(:role) { create(:role, name: :data_admin) }
@@ -20,9 +20,11 @@ RSpec.describe "Dashboards", type: :request do
 
         before { sign_in user }
 
-        it "renders the 'index' template" do
+        it "redirects to the classification page" do
           get(path)
-          expect(response.body).to include("Dashboard")
+          expect(response.body).to include(
+            "You are being <a href=\"http://www.example.com/classifications/call_types\">redirected</a>",
+          )
         end
       end
     end
@@ -51,6 +53,7 @@ RSpec.describe "Dashboards", type: :request do
 
       it "does not include the 'Users' menu item" do
         get(path)
+        get(response.headers["Location"])
 
         html = Nokogiri::HTML(response.body.to_s)
         users_link = html.css('//a[@href="/users"]')


### PR DESCRIPTION
## Overview

Redirect users from the dashboard to the classifications page. To ensure all users can see the classifications page, the permission `index :classifications` was added to all roles.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #48

## Changes

- Redirect to classifications from dashboard
- Add `index :classifications` permission to all roles
- Remove link from data set card if users can't actually classify data
- Fix specs 

## Notes

As I expect this change to be temporary, I have not updated the `root_path`. This means that if a user attempts to access a page they are not authorized to see, they will be redirect to the `root_path` (which is the dashboard) and then redirected once more to the classifications page. Let me know if you think this change will be longer term than I thought and I will adjust the code. If so, I might remove the `dashboard` nav item entirely for the time being.