### PR TITLE
Fix stacked buttons when screen is less than 1200px wide

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -37,7 +37,7 @@
     }
 
     .button, input[type="submit"] {
-        @apply relative inline-flex items-center px-6 py-2 border border-transparent shadow-sm text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer;
+        @apply relative inline-flex items-center px-6 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer;
     }
 
     a.button-secondary, button.button-secondary {
@@ -46,13 +46,13 @@
 
     .button-orange {
         @apply relative inline-flex items-center px-6 py-2 border border-transparent
-               shadow-sm text-base font-medium rounded-md text-white bg-orange-500
+               shadow-sm text-sm font-medium rounded-md text-white bg-orange-500
                hover:bg-orange-700 cursor-pointer;
     }
 
     .button-white {
         @apply relative inline-flex items-center px-6 py-2 border border-transparent
-               shadow-sm text-base font-medium rounded-md text-gray-500 bg-white
+               shadow-sm text-sm font-medium rounded-md text-gray-500 bg-white
                hover:bg-zinc-200 cursor-pointer;
     }
 

--- a/app/controllers/data_sets_controller.rb
+++ b/app/controllers/data_sets_controller.rb
@@ -4,7 +4,7 @@ class DataSetsController < ApplicationController
 
   def index
     authorize! :index, :data_sets
-    @data_sets = DataSet.ordered
+    @data_sets = DataSet.includes(files_attachments: :blob).ordered
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
 
   def index
     authorize! :index, :users
-    @users = User.order(created_at: :desc).page(params[:page] || 1).per(10)
+    @users = User.includes(:role).order(created_at: :desc).page(params[:page] || 1).per(10)
   end
 
   def edit

--- a/app/views/data_sets/_data_set.html.erb
+++ b/app/views/data_sets/_data_set.html.erb
@@ -1,9 +1,6 @@
 <div class="header">
-  <div class="py-3 sm:px-3">
-    <h3>
-      <%= @data_set.title %>
-    </h3>
-    <p class="description">
+  <div class="sm:px-3">
+    <p class="pb-3 description">
       <%= @data_set.description %>
     </p>
   </div>
@@ -14,7 +11,6 @@
       <%= render partial: 'data_sets/data_details', locals: {label: 'Location', value: "#{data_set.city}, #{data_set.state}", index: 0} %>
       <%= render partial: 'data_sets/data_details', locals: {label: 'Size', value: "#{number_to_human_size(data_set.storage_size)} (#{data_set.row_count} x #{data_set.fields.count})", index: 1} %>
       <%= render partial: 'data_sets/data_details', locals: {label: 'License', value:  data_set.license, index: 0} %>
-
       <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
         <dt class="text-sm font-medium text-gray-500">Links</dt>
         <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
@@ -36,14 +32,11 @@
                 </li>
               <% end %>
             <% end %>
-
           </ul>
         </dd>
       </div>
-
       <%= render partial: 'data_sets/data_details', locals: {label: 'Exclusions', value: data_set.exclusions, index: 0} %>
       <%= render partial: 'data_sets/data_details', locals: {label: 'Format', value: data_set.format, index: 1} %>
-
       <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
         <dt class="text-sm font-medium text-gray-500">Scope</dt>
         <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
@@ -104,4 +97,3 @@
     </dl>
   </div>
 </div>
-

--- a/app/views/data_sets/show.html.erb
+++ b/app/views/data_sets/show.html.erb
@@ -4,7 +4,7 @@
     description: @data_set.description,
     buttons: [
       { label: "Edit", href: edit_data_set_path(@data_set) },
-      { label: "List Datasets", href: edit_data_set_path(@data_set), class: "button-secondary" }
+      { label: "List Datasets", href: data_sets_path, class: "button-secondary" }
     ]
   %>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
 <div class="bg-white pt-12 px-12">
   <div class="flex flex-row">
-    <div class="grow">
+    <div class="grow w-2/4">
       <h3 class="text-2xl text-gray-900 font-bold"><%= title %></h3>
       <% if defined?(description) && description %>
-        <p class="mt-1 text-sm text-gray-500 w-2/4">
+        <p class="mt-1 text-sm text-gray-500 line-clamp-2 pr-12 2xl:w-3/4">
           <%= description %>
         </p>
       <% end %>
@@ -14,7 +14,7 @@
           <%= link_to button[:label],
                       button[:href],
                       method: button[:method] || :get,
-                      class: "#{button[:class] ? button[:class] : "button"}" %>
+                      class: "#{button[:class] ? button[:class] : "button"} mb-2" %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## Overview

Fix stacked buttons for medium screen sizes as well as a few other minor issues.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related tickets

Fixes #[63](https://github.com/codeforamerica/classifyr/issues/63)

## Changes

- Ensure buttons in page header don't get stacked
- Set a max size for the header description to 2 lines
- Fix 2 N+1 queries (for user roles and data set file attachments). There is one left for data set fields that involve custom queries to load the start and end times so I haven't changed it yet. 
- Reduce text size for all buttons to `text-sm` (there was a mix of `sm` and `base`)
- Fix link for the "List Datasets" buttons

## Notes

![buttons](https://user-images.githubusercontent.com/2647689/186403729-61416ba6-eb94-40e3-a630-0c0f402476fd.PNG)

