### PR TITLE
Adjust data sets table

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -93,7 +93,7 @@
     }
 
     table tr td {
-        @apply first:p-6 font-medium text-sm text-gray-900 py-2 px-4 whitespace-nowrap;
+        @apply first:p-6 font-medium text-sm text-gray-900 py-2 px-3 whitespace-nowrap;
     }
 
     h3 {

--- a/app/helpers/data_sets_helper.rb
+++ b/app/helpers/data_sets_helper.rb
@@ -4,4 +4,12 @@ module DataSetsHelper
 
     "bg-white"
   end
+
+  def location(data_set)
+    return "" unless data_set.city.present? || data_set.state.present?
+    return data_set.city if data_set.city.present? && data_set.state.blank?
+    return data_set.state if data_set.city.blank? && data_set.state.present?
+
+    "#{data_set.city}, #{data_set.state}"
+  end
 end

--- a/app/views/data_sets/index.html.erb
+++ b/app/views/data_sets/index.html.erb
@@ -8,42 +8,42 @@
     ]
   %>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
-    <div class="mt-12 px-4 py-5 sm:px-6">
+    <div class="mt-12 py-5">
       <section class="px-6 pb-6 bg-white">
-        <div class="overflow-hidden">
+        <div class="overflow-x-auto">
           <table class="min-w-full">
             <thead class="bg-gray-50 border-b">
               <tr>
-                <th scope="col" class="text-sm px-6 py-4">Name</th>
-                <th scope="col" class="text-sm px-6 py-4">Location</th>
-                <th scope="col" class="text-sm px-6 py-4">Timeframe</th>
-                <th scope="col" class="text-sm px-6 py-4">Files</th>
-                <th scope="col" class="text-sm px-6 py-4">Rows</th>
-                <th scope="col" class="text-sm px-6 py-4">Fields</th>
+                <th scope="col">Name</th>
+                <th scope="col">Location</th>
+                <th scope="col">Timeframe</th>
+                <th scope="col">Files</th>
+                <th scope="col">Rows</th>
+                <th scope="col">Fields</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
               <% @data_sets.each do |data_set| %>
                 <tr class="row">
-                  <td class="text-sm px-6 py-4">
+                  <td>
                     <%= link_to data_set.title, data_set %>
                   </td>
-                  <td class="text-sm px-6 py-4"><%= data_set.city %>, <%= data_set.state %></td>
-                  <td class="text-sm px-6 py-4"><%= data_set.timeframe %></td>
-                  <td class="text-sm px-6 py-4">
+                  <td><%= location(data_set) %></td>
+                  <td><%= data_set.timeframe %></td>
+                  <td>
                     <% data_set.files.each do |file| %>
                       <%= file.filename %>
                       <br>
                     <% end %>
                   </td>
-                  <td class="text-sm px-6 py-4">
+                  <td>
                     <%= data_set.row_count %>
                   </td>
-                  <td class="text-sm px-6 py-4">
+                  <td>
                     <%= data_set.datafile.headers ? data_set.files.first.headers.split(',').count : 0 %>
                   </td>
-                  <td class="text-sm px-6 py-4">
+                  <td>
                     <div class="inline-block ml-2">
                       <%= link_to edit_data_set_path(data_set), class: 'inline-block', title: 'Edit Dataset' do %>
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/app/views/shared/common_incident_types/_search_bar.html.erb
+++ b/app/views/shared/common_incident_types/_search_bar.html.erb
@@ -8,7 +8,6 @@
     placeholder: "Type to search...",
     autocomplete: "off",
     class: "rounded-input",
-    autofocus: true,
     data: {
       action: "filtering#submit selected-incident-type@window->filtering#disable deselected-incident-type@window->filtering#enable"
     }

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,65 +4,61 @@
     description: "List of users in the system."
   %>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
-    <div class="my-12 px-4 py-5 sm:px-6">
-      <div id="users" class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
-        <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="overflow-hidden">
-              <table class="min-w-full">
-                <thead class="bg-gray-50 border-b">
-                  <tr>
-                    <th scope="col" class="text-sm px-6 py-4">Email</th>
-                    <th scope="col" class="text-sm px-6 py-4">Role</th>
-                    <th scope="col" class="text-sm px-6 py-4">Sign In Count</th>
-                    <th scope="col" class="text-sm px-6 py-4">Last Sign In</th>
-                    <th scope="col" class="text-sm px-6 py-4">Confirmed</th>
-                    <th scope="col" class="text-sm px-6 py-4">Created At</th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <% @users.each do |user| %>
-                    <tr>
-                      <td class="text-sm px-6 py-4"><%= link_to user.email, edit_user_path(user) %></td>
-                      <td class="text-sm px-6 py-4"><%= user.role %></td>
-                      <td class="text-sm px-6 py-4 text-center"><%= user.sign_in_count %></td>
-                      <td class="text-sm px-6 py-4"><%= user.last_sign_in_at ? "#{time_ago_in_words(user.last_sign_in_at)} ago" : "" %></td>
-                      <td class="text-sm px-6 py-4 flex justify-center">
-                        <% if user.confirmed_at %>
-                          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                          </svg>
-                        <% else %>
-                          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500" viewBox="0 0 20 20" fill="currentColor">
-                            <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd" />
+    <div class="mt-12 py-5">
+      <section class="px-6 pb-6 bg-white">
+        <div class="overflow-x-auto">
+          <table class="min-w-full">
+            <thead class="bg-gray-50 border-b">
+              <tr>
+                <th scope="col">Email</th>
+                <th scope="col">Role</th>
+                <th scope="col">Sign In Count</th>
+                <th scope="col">Last Sign In</th>
+                <th scope="col">Confirmed</th>
+                <th scope="col">Created At</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @users.each do |user| %>
+                <tr class="row">
+                  <td><%= link_to user.email, edit_user_path(user) %></td>
+                  <td><%= user.role %></td>
+                  <td class="text-sm px-3 py-4 text-center"><%= user.sign_in_count %></td>
+                  <td><%= user.last_sign_in_at ? "#{time_ago_in_words(user.last_sign_in_at)} ago" : "" %></td>
+                  <td class="text-sm px-3 py-4 flex justify-center">
+                    <% if user.confirmed_at %>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    <% else %>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd" />
+                      </svg>
+                    <% end %>
+                  </td>
+                  <td><%= user.created_at.strftime("%B %d, %Y") %></td>
+                  <td>
+                    <% if current_user != user %>
+                      <div class="inline-block ml-2">
+                        <%= link_to edit_user_path(user), class: 'inline-block', title: 'Edit User' do %>
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                           </svg>
                         <% end %>
-                      </td>
-                      <td class="text-sm px-6 py-4"><%= user.created_at.strftime("%B %d, %Y") %></td>
-                      <td class="text-sm px-6 py-4">
-                        <% if current_user != user %>
-                          <div class="inline-block ml-2">
-                            <%= link_to edit_user_path(user), class: 'inline-block', title: 'Edit User' do %>
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                              </svg>
-                            <% end %>
-                            <%= link_to user_path(user), class: 'inline-block ml-1', title: 'Delete User', data: {"turbo-confirm": "Are you sure you want to delete this user?", "turbo-method": :delete } do %>
-                              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                              </svg>
-                            <% end %>
-                          </div>
+                        <%= link_to user_path(user), class: 'inline-block ml-1', title: 'Delete User', data: {"turbo-confirm": "Are you sure you want to delete this user?", "turbo-method": :delete } do %>
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                          </svg>
                         <% end %>
-                      </td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-              <%= paginate @users %>
-            </div>
-          </div>
+                      </div>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <%= paginate @users %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Overview

Fix the data sets table to be scrollable like the other tables. Also reduced the padding between table columns to increase the amount of data displayed for medium screen sizes.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related tickets

Fixes [#70](https://github.com/codeforamerica/classifyr/issues/70)

## Changes

- Add horizontal scrolling to the data sets table
- Move all `td` paddings back to the tailwind configuration file and reduce it to `px-3`
- Added a helper for the data set location

