### PR TITLE
Fix messaging after sign up

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,11 @@
 require "health-monitor-rails"
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: "registrations" }, skip: [:sessions, :registrations]
+  devise_for :users, controllers: { registrations: "registrations" }, skip: [:sessions]
   as :user do
     get "login", to: "devise/sessions#new", as: :new_user_session
     post "login", to: "devise/sessions#create", as: :user_session
     delete "logout", to: "devise/sessions#destroy", as: :destroy_user_session
-
-    get "sign_up", to: "devise/registrations#new", as: :new_user_registration
-    post "sign_up", to: "devise/registrations#create", as: :user_registration
 
     get "profile", to: "devise/registrations#edit"
     put "profile", to: "devise/registrations#update"

--- a/spec/features/authentication/auth_flow_spec.rb
+++ b/spec/features/authentication/auth_flow_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Auth flow", type: :feature do
 
       # Redirects to Log in page
       expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content("A message with a confirmation link has been sent to your email address.")
 
       # Expect confirmation email to be sent out
       expect(ActionMailer::Base.deliveries.length).to eq(1)


### PR DESCRIPTION
## Overview

I discovered an issue in the sign up flow. After adjusting the Devise routes, it appears the usual messaging ("A message with a confirmation link has been sent...") stopped appearing. This PR fixes this issue and includes an update to the tests to prevent a future regression.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related tickets

/

## Changes

- Ensure confirmation notice is properly displayed after signing up
