### PR TITLE
Add the use of SES and S3 in development environments.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,9 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  if ENV['AWS_S3_BUCKET'].present?
+    config.active_storage.service = :amazon
+  end
 
   # Raise an error if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
@@ -70,8 +73,12 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
-  config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = ENV.fetch('RAILS_DELIVERY_METHOD',
+                                                   'letter_opener').to_sym
+  if config.action_mailer.delivery_method == :letter_opener
+    config.action_mailer.perform_deliveries = true
+  end
+
 
   config.hosts << /^.+\.us-.+-\d.elb.amazonaws.com/
   config.hosts << /^.+\.nprd.classifyr.org/

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,7 +26,8 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "no-reply@classifyr.com"
+  email_domain = ENV.fetch("RAILS_EMAIL_DOMAIN", "classifyr.org")
+  config.mailer_sender = "no-reply@#{email_domain}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## Overview

Add optional environment variables in development for enabling SES and S3.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

n/a

## Changes

- Added support for `AWS_S3_BUCKET` in development
- Added support for `RAILS_DELIVERY_METHOD` in development
- Added support for `RAILS_EMAIL_DOMAIN`

## Notes

Tested on https://development.nprd.classifyr.org
