### PR TITLE
#78: Ensure unique common incident types.

### DIFF
--- a/db/migrate/20220829191431_unique_common_incident_types.rb
+++ b/db/migrate/20220829191431_unique_common_incident_types.rb
@@ -1,0 +1,10 @@
+class UniqueCommonIncidentTypes < ActiveRecord::Migration[7.0]
+  def change
+    # Remove duplicate records before adding the unique key.
+    keepers = CommonIncidentType.select('MIN(id) AS id')
+                                .group(:standard, :version, :code)
+    CommonIncidentType.excluding(keepers).destroy_all
+
+    add_index :common_incident_types, [:standard, :version, :code], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_22_131638) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_29_191431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_22_131638) do
     t.datetime "updated_at", null: false
     t.string "humanized_code"
     t.string "humanized_description"
+    t.index ["standard", "version", "code"], name: "index_common_incident_types_on_standard_and_version_and_code", unique: true
   end
 
   create_table "data_sets", force: :cascade do |t|

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -46,15 +46,16 @@ RSpec.describe DataSet, type: :model do
         create_list(:classification, 1, unique_value: unique_value_3)
 
         # Oldest with lowest completion first
-        expect(described_class.to_classify.map(&:id)).to eq(
-          [
-            # data_set_5.id is not present because it doesn't have a Call Type field
-            data_set_3.id, # Oldest one with no completion
-            data_set_4.id, # More recent with no completion
-            data_set_2.id, # Partial completion 1/2 unique values classified
-            data_set_1.id, # Completed is last
-          ],
-        )
+        expect(described_class.to_classify.map(&:id)).to \
+          eq(
+           [
+             # data_set_5.id is not present because it doesn't have a Call Type field
+             data_set_3.id, # Oldest one with no completion
+             data_set_4.id, # More recent with no completion
+             data_set_2.id, # Partial completion 1/2 unique values classified
+             data_set_1.id, # Completed is last
+           ],
+         )
       end
     end
   end
@@ -162,11 +163,6 @@ RSpec.describe DataSet, type: :model do
 
     describe "#analyze!" do
       it "analyses a datafile" do
-        CSV.foreach(Rails.root.join("db/import/apco_common_incident_types_2.103.2-2019.csv"),
-                    headers: true) do |line|
-          CommonIncidentType.create! code: line[0], description: line["description"], notes: line["notes"]
-        end
-
         data_set = create(:data_set, files: [
                             Rack::Test::UploadedFile.new("spec/support/files/police-incidents-2022.csv", "text/csv"),
                           ])
@@ -179,16 +175,15 @@ RSpec.describe DataSet, type: :model do
 
         expect(data_set.reload.analyze!).to be(true)
 
-        expect(data_set.fields.find_by(heading: "call_type").unique_values.
-          pluck(:value).map { |v| v.delete("\u0002") }).to eq(
-          [
-            "Welfare Check",
-            "Trespass",
-            "Mental Health Issue",
-            "Intoxication",
-            "DUI",
-          ],
-        )
+        expect(data_set.fields.find_by(heading: "call_type").unique_values
+                       .pluck(:value).map { |v| v.delete("\u0002") }).to \
+                         eq([
+                              "Welfare Check",
+                              "Trespass",
+                              "Mental Health Issue",
+                              "Intoxication",
+                              "DUI",
+                            ])
       end
     end
 


### PR DESCRIPTION
## Overview

Make common incident types unique across standard and version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

Fixes #78

## Changes

- Added unique key to the common incident types
- Removing duplicate common incident types

## Notes

Migration tested locally.
