### PR TITLE
#84: Updated call type gathering to use a CSV parser.

### DIFF
--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -176,14 +176,13 @@ RSpec.describe DataSet, type: :model do
         expect(data_set.reload.analyze!).to be(true)
 
         expect(data_set.fields.find_by(heading: "call_type").unique_values
-                       .pluck(:value).map { |v| v.delete("\u0002") }).to \
-                         eq([
-                              "Welfare Check",
-                              "Trespass",
-                              "Mental Health Issue",
-                              "Intoxication",
-                              "DUI",
-                            ])
+                       .pluck(:value)).to(eq([
+                                               "Welfare Check",
+                                               "DUI",
+                                               "Intoxication",
+                                               "Mental Health Issue",
+                                               "Trespass",
+                                             ]))
       end
     end
 


### PR DESCRIPTION
Fixes an issue where datasets that included special characters would result in a single, empty call type.

## Overview

Moved parsing of the CSV for call types to the csv gem rather than shelling out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

Fixes #84

## Changes

- Moved parsing of the CSV for call types to the csv gem rather than shelling out.

## Notes

Tested locally
