### PR TITLE
Fix production stylesheet and remove duplicated stylesheet

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
   <body class="bg-gray-100">

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -6,10 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-
   <body class="flex flex-col bg-gray-800 h-screen">
     <div class="w-full">
       <% if notice %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.public_file_server.enabled = ENV.fetch("RAILS_SERVE_STATIC_FILES") { true }
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
## Overview

1. Update production config to load files from public by default

2. Remove duplicated non-compiled stylesheets. I noticed that the app was trying to load all the Tailwind CSS import as external files and found out it was coming from this line:

```
<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
```

All styles are defined within the Tailwind main file at the moment so there is no need to load the `application.css` (which isn't getting built properly).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related tickets

/

## Changes

- Change default value for `config.public_file_server.enabled`
- Remove `application.css` reference
