### PR TITLE
Add APCO codes table

### DIFF
--- a/app/controllers/classifications/call_types_controller.rb
+++ b/app/controllers/classifications/call_types_controller.rb
@@ -22,6 +22,7 @@ class Classifications::CallTypesController < ApplicationController
   def show
     authorize! :create, :classifications
 
+    @apco_codes = CommonIncidentType.apco
     @data_set = @call_type.data_set
     @fields = @data_set.fields.order(:position)
     @data = @call_type&.examples

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["hide", "temporaryHide"];
+
+  show() {
+    this.hideTargets.forEach((el) => {
+      el.classList.remove("hidden");
+    });
+
+    this.hideTemporary();
+  }
+
+  hide() {
+    this.hideTargets.forEach((el) => {
+      el.classList.add("hidden");
+    });
+
+    this.showTemporary();
+  }
+
+  showTemporary() {
+    this.temporaryHideTargets.forEach((el) => {
+      el.classList.remove("hidden");
+    });
+  }
+
+  hideTemporary() {
+    this.temporaryHideTargets.forEach((el) => {
+      el.classList.add("hidden");
+    });
+  }
+}

--- a/app/models/common_incident_type.rb
+++ b/app/models/common_incident_type.rb
@@ -23,6 +23,8 @@ class CommonIncidentType < ApplicationRecord
 
   has_many :classifications, dependent: :destroy
 
+  scope :apco, -> { where(standard: "APCO") }
+
   def self.to_csv
     cits = all
     CSV.generate do |csv|

--- a/app/views/classifications/call_types/_codes.html.erb
+++ b/app/views/classifications/call_types/_codes.html.erb
@@ -1,0 +1,23 @@
+<h4 class="px-6 pt-6 border-b-2 border-gray-200">
+  APCO Codes
+</h4>
+<section class="px-6 pb-6 bg-white mb-12 h-96 overflow-y-scroll">
+  <table class="table-fixed lg:w-full border-collapse">
+    <thead>
+      <tr>
+        <th class="w-1/5" scope="col">Code</th>
+        <th class="w-2/5" scope="col">Description</th>
+        <th class="w-2/5" scope="col">Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% apco_codes.each do |apco_code| %>
+        <tr class="row">
+          <td class="p-1"><%= apco_code.code %></td>
+          <td class="p-1 break-normal whitespace-normal"><%= apco_code.description %></td>
+          <td class="p-1 break-normal whitespace-normal"><%= apco_code.notes %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/classifications/call_types/show.html.erb
+++ b/app/views/classifications/call_types/show.html.erb
@@ -42,11 +42,26 @@
           </div>
         </section>
       </section>
-      <section id="classify-call-type">
-        <h2>Classify Call Type</h2>
-        <div class="text-black pb-8">
-          Assign a common incident type to this data set.
+      <section id="classify-call-type" data-controller="visibility">
+        <div class="flex flex-col lg:flex-row justify-between">
+          <div>
+            <h2>Classify Call Type</h2>
+            <div class="text-black pb-8">
+              Assign a common incident type to this data set.
+            </div>
+          </div>
+          <div class="mb-8">
+            <button id="show-apco" class="button" data-action="click->visibility#show" data-visibility-target="temporaryHide">
+              View all APCO codes
+            </button>
+            <button class="button hidden" data-action="click->visibility#hide" data-visibility-target="hide">
+              Hide APCO codes
+            </button>
+          </div>
         </div>
+        <section data-visibility-target="hide" class="hidden bg-white mb-12">
+          <%= render 'codes', apco_codes: @apco_codes %>
+        </section>
         <% if @existing_classication %>
           <p class="mx-auto notice-border w-1/2 mb-12" id="notice">
             You classified this call type

--- a/db/migrate/20220907015121_rename_common_incident_types_version_to_code_version.rb
+++ b/db/migrate/20220907015121_rename_common_incident_types_version_to_code_version.rb
@@ -1,0 +1,8 @@
+class RenameCommonIncidentTypesVersionToCodeVersion < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :common_incident_types, name: "index_common_incident_types_on_standard_and_version_and_code"
+    rename_column :common_incident_types, :version, :code_version
+    add_index :common_incident_types, [:standard, :code_version, :code],
+              name: "index_common_incident_types_on_standard_and_version_and_code"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_07_015121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -26,8 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
     t.date "start_date"
     t.date "end_date"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index %w[record_type record_id name blob_id], name: "index_active_storage_attachments_uniqueness",
-                                                    unique: true
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -45,7 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index %w[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "classifications", force: :cascade do |t|
@@ -61,12 +60,12 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
     t.bigint "unique_value_id"
     t.index ["common_incident_type_id"], name: "index_classifications_on_common_incident_type_id"
     t.index ["unique_value_id"], name: "index_classifications_on_unique_value_id"
-    t.index %w[user_id unique_value_id], name: "index_classifications_on_user_id_and_unique_value_id", unique: true
+    t.index ["user_id", "unique_value_id"], name: "index_classifications_on_user_id_and_unique_value_id", unique: true
   end
 
   create_table "common_incident_types", force: :cascade do |t|
     t.string "standard", default: "APCO"
-    t.string "version", default: "2.103.2-2019"
+    t.string "code_version", default: "2.103.2-2019"
     t.string "code"
     t.string "description"
     t.string "notes"
@@ -74,8 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
     t.datetime "updated_at", null: false
     t.string "humanized_code"
     t.string "humanized_description"
-    t.index %w[standard version code], name: "index_common_incident_types_on_standard_and_version_and_code",
-                                       unique: true
+    t.index ["standard", "code_version", "code"], name: "index_common_incident_types_on_standard_and_version_and_code"
   end
 
   create_table "data_sets", force: :cascade do |t|
@@ -126,10 +124,9 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
     t.string "sluggable_type", limit: 50
     t.string "scope"
     t.datetime "created_at"
-    t.index %w[slug sluggable_type scope], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope",
-                                           unique: true
-    t.index %w[slug sluggable_type], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
-    t.index %w[sluggable_type sluggable_id], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -188,7 +185,7 @@ ActiveRecord::Schema[7.0].define(version: 20_220_829_191_431) do
     t.text "object"
     t.datetime "created_at"
     t.text "object_changes"
-    t.index %w[item_type item_id], name: "index_versions_on_item_type_and_item_id"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/features/classifications/classify_flow_spec.rb
+++ b/spec/features/classifications/classify_flow_spec.rb
@@ -87,6 +87,22 @@ RSpec.describe "Classify call types", type: :feature, js: true do
     end
   end
 
+  context "when checking the APCO codes table" do
+    it "displays the APCO codes" do
+      go_to_classify(jack, data_set_1)
+      check_classify_page(unique_value_1_1)
+
+      find("#show-apco").click
+
+      first_cit = CommonIncidentType.first
+      last_cit = CommonIncidentType.last
+
+      expect(page).to have_content("APCO Codes")
+      expect(page).to have_content(first_cit.code)
+      expect(page).to have_content(last_cit.code)
+    end
+  end
+
   context "when cancelling and trying again" do
     it "allows the user to search again" do
       go_to_classify(jack, data_set_1)


### PR DESCRIPTION
## Overview

Add a list of all APCO code on the classification page.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #86

## Changes

- Add APCO code table to classifications code that can be displayed or hidden with a button.

## Notes

![viewapco](https://user-images.githubusercontent.com/2647689/188790469-80f8bb32-f6b2-4ee7-b5dc-8224496a3018.PNG)

![shownapco](https://user-images.githubusercontent.com/2647689/188790477-c1ad95a8-31af-4017-b57e-686581bfa759.PNG)

