### PR TITLE
Use humanized values for Common Incident Types

### DIFF
--- a/app/controllers/common_incident_types_controller.rb
+++ b/app/controllers/common_incident_types_controller.rb
@@ -5,7 +5,7 @@ class CommonIncidentTypesController < ApplicationController
     @results = nil
 
     if params[:q].present?
-      @results = CommonIncidentType.search(params[:q])
+      @results = CommonIncidentType.search(params[:q]).to_a
     end
 
     render layout: false

--- a/app/models/common_incident_type.rb
+++ b/app/models/common_incident_type.rb
@@ -5,7 +5,8 @@ class CommonIncidentType < ApplicationRecord
   pg_search_scope :search,
                   against: [
                     :code, :description, :notes,
-                    :humanized_code, :humanized_description
+                    :humanized_code, :humanized_description,
+                    :humanized_notes
                   ],
                   using: {
                     tsearch: {
@@ -24,6 +25,18 @@ class CommonIncidentType < ApplicationRecord
   has_many :classifications, dependent: :destroy
 
   scope :apco, -> { where(standard: "APCO") }
+
+  def formatted_code
+    humanized_code || code
+  end
+
+  def formatted_description
+    humanized_description || description
+  end
+
+  def formatted_notes
+    humanized_notes || notes
+  end
 
   def self.to_csv
     cits = all

--- a/app/views/classifications/call_types/_codes.html.erb
+++ b/app/views/classifications/call_types/_codes.html.erb
@@ -13,9 +13,9 @@
     <tbody>
       <% apco_codes.each do |apco_code| %>
         <tr class="row">
-          <td class="p-1"><%= apco_code.code %></td>
-          <td class="p-1 break-normal whitespace-normal"><%= apco_code.description %></td>
-          <td class="p-1 break-normal whitespace-normal"><%= apco_code.notes %></td>
+          <td class="p-1"><%= apco_code.formatted_code %></td>
+          <td class="p-1 break-normal whitespace-normal"><%= apco_code.formatted_description %></td>
+          <td class="p-1 break-normal whitespace-normal"><%= apco_code.formatted_notes %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -44,7 +44,7 @@
                           UNKNOWN
                         </i>
                       <% else %>
-                        <%= link_to classification.common_incident_type&.code, '#', title: classification.common_incident_type&.notes || classification.common_incident_type&.description %>
+                        <%= link_to classification.common_incident_type&.formatted_code, '#', title: classification.common_incident_type&.formatted_notes || classification.common_incident_type&.formatted_description %>
                       <% end %>
                     </td>
                     <td>

--- a/app/views/shared/common_incident_types/_card.html.erb
+++ b/app/views/shared/common_incident_types/_card.html.erb
@@ -1,12 +1,12 @@
 <div data-incident-id="<%= common_incident_type.id %>" data-classify-target="incidentTypeCard" class="flex flex-col bg-white border-gray-200 shadow rounded">
   <div class="grow p-8">
-    <div class="text-xl font-bold pb-3"><%= common_incident_type.description %></div>
-    <div class="text-sm text-gray-600 pb-2 h-10 line-clamp-2"><%= common_incident_type.notes %></div>
+    <div class="text-xl font-bold pb-3"><%= common_incident_type.formatted_description %></div>
+    <div class="text-sm text-gray-600 pb-2 h-10 line-clamp-2"><%= common_incident_type.formatted_notes %></div>
   </div>
   <div class="flex flex-row bg-neutral-100">
     <div class="px-8 py-6 w-50">
       <div class="text-sm text-gray-600 mb-4"><%= common_incident_type.standard %> Code</div>
-      <div class="bg-blue-100 rounded-2xl px-5 py-1.5 text-md text-blue-600 ml-4"><%= common_incident_type.code %></div>
+      <div class="bg-blue-100 rounded-2xl px-5 py-1.5 text-md text-blue-600 ml-4"><%= common_incident_type.formatted_code %></div>
     </div>
     <div class="flex flex-grow justify-end px-8 w-50">
       <button data-action="click->classify#selectIncidentType" class="button h-12 self-center">

--- a/db/migrate/20220908043707_add_humanized_notes_to_common_incident_types.rb
+++ b/db/migrate/20220908043707_add_humanized_notes_to_common_incident_types.rb
@@ -1,0 +1,5 @@
+class AddHumanizedNotesToCommonIncidentTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :common_incident_types, :humanized_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_07_015121) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_08_073304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -73,6 +73,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_07_015121) do
     t.datetime "updated_at", null: false
     t.string "humanized_code"
     t.string "humanized_description"
+    t.text "humanized_notes"
+    t.index "to_tsvector('simple'::regconfig, COALESCE((code)::text, ''::text))", name: "index_common_incident_types_on_code", using: :gin
     t.index ["standard", "code_version", "code"], name: "index_common_incident_types_on_standard_and_version_and_code"
   end
 
@@ -147,6 +149,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_07_015121) do
     t.string "slug"
     t.datetime "created_at", default: -> { "now()" }, null: false
     t.datetime "updated_at", default: -> { "now()" }, null: false
+    t.json "examples", default: [], null: false
     t.index ["field_id"], name: "index_unique_values_on_field_id"
     t.index ["slug"], name: "index_unique_values_on_slug", unique: true
   end

--- a/spec/features/classifications/classify_flow_spec.rb
+++ b/spec/features/classifications/classify_flow_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe "Classify call types", type: :feature, js: true do
   end
 
   def check_incident_type_card(incident_type)
-    expect(page).to have_content(incident_type.code)
-    expect(page).to have_content(incident_type.description)
-    expect(page).to have_content(incident_type.notes)
+    expect(page).to have_content(incident_type.formatted_code)
+    expect(page).to have_content(incident_type.formatted_description)
+    expect(page).to have_content(incident_type.formatted_notes)
   end
 
   def check_data_completion(data_set, percent, completed, total)
@@ -98,8 +98,8 @@ RSpec.describe "Classify call types", type: :feature, js: true do
       last_cit = CommonIncidentType.last
 
       expect(page).to have_content("APCO Codes")
-      expect(page).to have_content(first_cit.code)
-      expect(page).to have_content(last_cit.code)
+      expect(page).to have_content(first_cit.formatted_code)
+      expect(page).to have_content(last_cit.formatted_code)
     end
   end
 

--- a/spec/models/common_incident_type_spec.rb
+++ b/spec/models/common_incident_type_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CommonIncidentType, type: :model do
         expect(csv).to include(CommonIncidentType::EXPORT_COLUMNS.join(","))
 
         common_incident_types.each do |common_incident_type|
-          expect(csv).to include(common_incident_type.code)
+          expect(csv).to include(common_incident_type.formatted_code)
         end
       end
     end


### PR DESCRIPTION
## Overview

Prioritize using humanized values for common incident types when present. Also introduce a `humanized_notes` field.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #13

## Changes

- Add `humanized_notes` to common incident types
- Ensure the common incident type search only generates one query by converting it to an array right away
- Add `formatted_*` method for common incident types that will return the humanized value if present, and default to the regular value if not.

