### PR TITLE
Fix input state when clicking on "Unable to Map"

### DIFF
--- a/app/javascript/controllers/classify_controller.js
+++ b/app/javascript/controllers/classify_controller.js
@@ -24,9 +24,7 @@ export default class extends Controller {
       "[data-classify-target='incidentTypeCard']"
     );
 
-    // Disable search input
-    const selectedEvent = new CustomEvent("selected-incident-type");
-    window.dispatchEvent(selectedEvent);
+    this.disableSearchInput();
 
     // Hide "Select" button of selected card and
     // show "Selected" button before cloning
@@ -57,9 +55,7 @@ export default class extends Controller {
     this.selectedIncidentCardTarget.innerHTML = "";
     this.selectedFormTarget.classList.add("hidden");
 
-    // Enable search input
-    const deselectedEvent = new CustomEvent("deselected-incident-type");
-    window.dispatchEvent(deselectedEvent);
+    this.enableSearchInput();
   }
 
   selectConfidenceRating(event) {
@@ -114,6 +110,7 @@ export default class extends Controller {
 
   submitUnknown(e) {
     e.preventDefault();
+    this.disableSearchInput();
     this.incidentTypeUnknownTarget.setAttribute("value", true);
     this.selectedFormTarget.requestSubmit();
   }
@@ -122,5 +119,16 @@ export default class extends Controller {
     e.preventDefault();
     this.selectedFormTarget.requestSubmit();
     this.selectedFormTarget.classList.add("hidden");
+  }
+
+  enableSearchInput() {
+    // Enable search input
+    const deselectedEvent = new CustomEvent("deselected-incident-type");
+    window.dispatchEvent(deselectedEvent);
+  }
+
+  disableSearchInput() {
+    const selectedEvent = new CustomEvent("selected-incident-type");
+    window.dispatchEvent(selectedEvent);
   }
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug where the search input was not properly deactivated when "Unable to map call type" was clicked.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Related tickets

Fixes #87

## Changes

- Disable input when "Unable to map is clicked"

## Notes

![ezgif-3-3218d4d820](https://user-images.githubusercontent.com/2647689/189071501-7a671dcc-4845-4d46-8d18-a35cb0f39e8b.gif)
