### PR TITLE
Add required input styling

### DIFF
--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -41,6 +41,10 @@
            rounded;
   }
 
+  .required:after {
+    content:"*";
+  }
+
   .jumbo {
     @apply font-semibold text-3xl mb-5
            text-indigo-600;

--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -41,6 +41,10 @@
            rounded;
   }
 
+  select.rounded-select {
+    @apply shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md;
+  }
+
   .required:after {
     content:"*";
   }

--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -42,7 +42,10 @@
   }
 
   select.rounded-select {
-    @apply shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md;
+    @apply shadow-sm focus:ring-indigo-500
+           focus:border-indigo-500
+           block w-full sm:text-sm border-gray-300
+           rounded-md;
   }
 
   .required:after {

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_with(model: [:admin, user], class: "contents") do |form| %>
   <%= render "shared/form/text_field", form: form,
                                        field: :email,
+                                       required: true,
+                                       type: :email,
                                        placeholder: "Enter an email" %>
   <%= render "shared/form/select", form: form,
                                    field: :role_id,

--- a/app/views/data_sets/_form.html.erb
+++ b/app/views/data_sets/_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_with(model: data_set, class: "contents") do |form| %>
   <%= render "shared/form/text_field", form: form,
                                        field: :title,
-                                       placeholder: "The name as listed on web page or report" %>
+                                       placeholder: "The name as listed on web page or report",
+                                       required: true %>
   <%= render "shared/form/text_area", form: form,
                                       field: :description,
                                       rows: 3,
@@ -36,7 +37,7 @@
                                    field: :state,
                                    options: options_for_select(us_states, form.object.state) %>
   <% if action_name == 'new' || action_name == 'create' %>
-    <%= render "shared/form/file_field", form: form, field: :files %>
+    <%= render "shared/form/file_field", form: form, field: :files, required: true %>
   <% end %>
   <div class="mb-12">
     <fieldset>

--- a/app/views/shared/form/_checkbox.html.erb
+++ b/app/views/shared/form/_checkbox.html.erb
@@ -1,9 +1,10 @@
 <div class="relative flex items-start">
   <div class="flex items-center h-5">
-    <%= form.check_box field, class: form.object.errors[field].any? ? "invalid" : "" %>
+    <%= form.check_box field, class: form.object.errors[field].any? ? "invalid" : "",
+                             required: defined?(required) ? required : false %>
   </div>
   <div class="ml-3 text-sm">
-    <label for="data_set_<%= field %>" class="<%= form.object.errors[field].any? ? "invalid" : "" %>"><%= label %></label>
+    <label for="data_set_<%= field %>" class="<%= form.object.errors[field].any? ? "invalid" : "" %> <%= defined?(required) ? "required" : "" %>"><%= label %></label>
     <p class="text-gray-500 <%= form.object.errors[field].any? ? "invalid" : "" %>"><%= description %></p>
   </div>
 </div>

--- a/app/views/shared/form/_checkbox.html.erb
+++ b/app/views/shared/form/_checkbox.html.erb
@@ -4,7 +4,12 @@
                              required: defined?(required) ? required : false %>
   </div>
   <div class="ml-3 text-sm">
-    <label for="data_set_<%= field %>" class="<%= form.object.errors[field].any? ? "invalid" : "" %> <%= defined?(required) ? "required" : "" %>"><%= label %></label>
+    <label
+      for="data_set_<%= field %>"
+      class="<%= form.object.errors[field].any? ? "invalid" : "" %> <%= defined?(required) ? "required" : "" %>"
+    >
+      <%= label %>
+    </label>
     <p class="text-gray-500 <%= form.object.errors[field].any? ? "invalid" : "" %>"><%= description %></p>
   </div>
 </div>

--- a/app/views/shared/form/_file_field.html.erb
+++ b/app/views/shared/form/_file_field.html.erb
@@ -1,5 +1,6 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
+  <%= form.label field,
+      class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.file_field field, multiple: true,
                              class: form.object.errors[field].any? ? "invalid" : "",
                              required: defined?(required) ? required : false %>

--- a/app/views/shared/form/_file_field.html.erb
+++ b/app/views/shared/form/_file_field.html.erb
@@ -1,6 +1,8 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""}" %>
-  <%= form.file_field field, multiple: true, class: form.object.errors[field].any? ? "invalid" : "" %>
+  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
+  <%= form.file_field field, multiple: true,
+                             class: form.object.errors[field].any? ? "invalid" : "",
+                             required: defined?(required) ? required : false %>
   <% if form.object.errors[field] %>
     <span class="flex items-center font-medium tracking-wide text-red-500 text-xs mt-1 ml-1">
       <%= form.object.errors.full_messages_for(field).join(", ") %>

--- a/app/views/shared/form/_select.html.erb
+++ b/app/views/shared/form/_select.html.erb
@@ -1,7 +1,8 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""}" %>
+  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.select field, options, {},
-                           { class: "#{form.object.errors[field].any? ? "invalid" : ""} shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md" } %>
+                           { class: "#{form.object.errors[field].any? ? "invalid" : ""} shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md",
+                             required: defined?(required) ? required : false } %>
   <% if form.object.errors[field] %>
     <span class="flex items-center font-medium tracking-wide text-red-500 text-xs mt-1 ml-1">
       <%= form.object.errors.full_messages_for(field).join(", ") %>

--- a/app/views/shared/form/_select.html.erb
+++ b/app/views/shared/form/_select.html.erb
@@ -1,8 +1,12 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
-  <%= form.select field, options, {},
-                           { class: "#{form.object.errors[field].any? ? "invalid" : ""} shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md",
-                             required: defined?(required) ? required : false } %>
+  <%= form.label field,
+      class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
+  <%= form.select field,
+      options, {},
+      {
+        class: "#{form.object.errors[field].any? ? "invalid" : ""} rounded-select",
+        required: defined?(required) ? required : false
+      } %>
   <% if form.object.errors[field] %>
     <span class="flex items-center font-medium tracking-wide text-red-500 text-xs mt-1 ml-1">
       <%= form.object.errors.full_messages_for(field).join(", ") %>

--- a/app/views/shared/form/_text_area.html.erb
+++ b/app/views/shared/form/_text_area.html.erb
@@ -1,5 +1,6 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
+  <%= form.label field,
+      class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.text_area field, placeholder: placeholder,
                             rows: rows,
                             class: form.object.errors[field].any? ? "invalid" : "",

--- a/app/views/shared/form/_text_area.html.erb
+++ b/app/views/shared/form/_text_area.html.erb
@@ -1,8 +1,9 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""}" %>
+  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.text_area field, placeholder: placeholder,
                             rows: rows,
-                            class: form.object.errors[field].any? ? "invalid" : "" %>
+                            class: form.object.errors[field].any? ? "invalid" : "",
+                            required: defined?(required) ? required : false %>
   <% if form.object.errors[field] %>
     <span class="flex items-center font-medium tracking-wide text-red-500 text-xs mt-1 ml-1">
       <%= form.object.errors.full_messages_for(field).join(", ") %>

--- a/app/views/shared/form/_text_field.html.erb
+++ b/app/views/shared/form/_text_field.html.erb
@@ -1,7 +1,9 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""}" %>
+  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.text_field field, placeholder: placeholder,
-                                class: form.object.errors[field].any? ? "invalid" : "" %>
+                              class: form.object.errors[field].any? ? "invalid" : "",
+                              type: defined?(type) ? type : "text",
+                              required: defined?(required) ? required : false %>
   <% if form.object.errors[field] %>
     <span class="flex items-center font-medium tracking-wide text-red-500 text-xs mt-1 ml-1">
       <%= form.object.errors.full_messages_for(field).join(", ") %>

--- a/app/views/shared/form/_text_field.html.erb
+++ b/app/views/shared/form/_text_field.html.erb
@@ -1,5 +1,6 @@
 <div class="sm:col-span-6 my-4">
-  <%= form.label field, class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
+  <%= form.label field,
+      class: "mb-1 #{form.object.errors[field].any? ? "invalid" : ""} #{defined?(required) ? "required" : ""}" %>
   <%= form.text_field field, placeholder: placeholder,
                               class: form.object.errors[field].any? ? "invalid" : "",
                               type: defined?(type) ? type : "text",


### PR DESCRIPTION
## Overview

Add an asterisk to the required fields and set up HTML validation. All field partials have been updated to support the `required` param.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #89

## Changes

- Show asterisk for required fields
- Set up HTML validation
- Add support for "email" type to the text field partial

## Notes

Let me know if you'd like to show the required fields in a different way.

![title](https://user-images.githubusercontent.com/2647689/189082898-c1932a3f-c94f-45be-aea2-2021568a17ef.PNG)

