### PR TITLE
#101: Add configuration options for the default role.

### DIFF
--- a/app/models/concerns/app_config.rb
+++ b/app/models/concerns/app_config.rb
@@ -1,0 +1,13 @@
+module AppConfig
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def app_config
+      Rails.application.config
+    end
+
+    def config
+      app_config.classifyr[name.underscore] ||= {}
+    end
+  end
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,6 @@
 class Role < ApplicationRecord
+  include AppConfig
+
   has_paper_trail
   has_many :users, dependent: :nullify
 
@@ -42,6 +44,7 @@ class Role < ApplicationRecord
       classifications: [:index, :create],
       common_incident_types: [:index],
       dashboard: [:index, :show],
+      data_sets: [:index, :show, :create, :update],
     },
     data_consumer: {
       classifications: [:index],
@@ -64,7 +67,7 @@ class Role < ApplicationRecord
   end
 
   def self.find_default_role
-    find_by(name: DEFAULT_ROLE_NAME)
+    find_by(name: config[:default] || DEFAULT_ROLE_NAME)
   end
 
   def to_s

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,8 @@ module Classifyr
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_storage.multiple_file_field_include_hidden = false
+
+    # Load custom configurations.
+    config.classifyr = config_for(:classifyr)
   end
 end

--- a/config/classifyr.yml
+++ b/config/classifyr.yml
@@ -1,0 +1,18 @@
+# Custom Classifyr configurations.
+default: &default
+  role:
+    # The role that is assigned to new users when they are created.
+    default: volunteer
+
+development:
+  <<: *default
+  role:
+    default: data_admin
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+  role:
+    default: data_classifier

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,6 +85,6 @@ Rails.application.configure do
     }
   end
 
-  config.hosts << /^[\w-\.]+\.us-.+-\d\.elb\.amazonaws\.com\z/
+  config.hosts << /^[\w\-\.]+\.us-.+-\d\.elb\.amazonaws\.com\z/
   config.hosts << /^.+\.nprd\.classifyr\.org\z/
 end

--- a/spec/requests/data_sets_spec.rb
+++ b/spec/requests/data_sets_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
 
@@ -48,7 +47,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
 
@@ -89,7 +87,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
       include_examples "unauthorized", :get, :volunteer
@@ -117,7 +114,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
       include_examples "unauthorized", :get, :volunteer
@@ -155,7 +151,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :post
 
     context "when authenticated" do
-      include_examples "unauthorized", :post, :data_classifier
       include_examples "unauthorized", :post, :data_consumer
       include_examples "unauthorized", :post, :data_reviewer
       include_examples "unauthorized", :post, :volunteer
@@ -210,7 +205,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :patch
 
     context "when authenticated" do
-      include_examples "unauthorized", :patch, :data_classifier
       include_examples "unauthorized", :patch, :data_consumer
       include_examples "unauthorized", :patch, :data_reviewer
       include_examples "unauthorized", :patch, :volunteer
@@ -301,7 +295,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
       include_examples "unauthorized", :get, :volunteer
@@ -338,7 +331,6 @@ RSpec.describe "DataSets", type: :request do
     include_examples "unauthenticated", :get
 
     context "when authenticated" do
-      include_examples "unauthorized", :get, :data_classifier
       include_examples "unauthorized", :get, :data_consumer
       include_examples "unauthorized", :get, :data_reviewer
       include_examples "unauthorized", :get, :volunteer


### PR DESCRIPTION
## Overview

Allows the default role for new users to be configured.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

Fixes #101

## Changes

- Added `classifyr.yml` configuration file for custom configs
- Added `AppConfig` concern to provide both application and model specific configs
- Updated `Role#find_default_role` to use the config if it has been set

## Notes

Tested locally.
