### PR TITLE
Add the ability to re-map non-classified data set fields

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -3,6 +3,7 @@ class Field < ApplicationRecord
 
   belongs_to :data_set
   has_many :unique_values, dependent: :destroy
+  has_many :classifications, through: :unique_values
 
   TYPES = [
     "", "Emergency Category", "Call Category", Classification::CALL_TYPE,
@@ -17,20 +18,34 @@ class Field < ApplicationRecord
   VALUE_TYPES = ["Emergency Category", "Call Category", Classification::CALL_TYPE, "Call Disposition",
                  "Priority"].freeze
 
-  def self.mapped
-    where("common_type IS NOT NULL AND common_type != ''")
+  scope :classified, -> { joins(:classifications).distinct }
+  scope :not_classified, -> { where.missing(:classifications).distinct }
+  scope :mapped, -> { where("fields.common_type IS NOT NULL AND fields.common_type != ''") }
+  scope :with_values, -> { where(common_type: VALUE_TYPES) }
+  scope :without_values, -> { where.not(common_type: VALUE_TYPES) }
+
+  def classified?
+    classifications.any?
   end
 
   def values?
     VALUE_TYPES.include? common_type
   end
 
-  def self.with_values
-    where(common_type: VALUE_TYPES)
-  end
+  def map_to(new_common_type)
+    new_common_type = nil if new_common_type.blank?
 
-  def self.without_values
-    where.not(common_type: VALUE_TYPES)
+    # If the field is classified or its common_type wasn't changed,
+    # we skip
+    return if classified? || common_type == new_common_type
+
+    # If the new common_type is not of interest, we delete the
+    # unique values.
+    unless Field::VALUE_TYPES.include?(new_common_type)
+      unique_values.destroy_all
+    end
+
+    update(common_type: new_common_type)
   end
 
   def pick_value_to_classify_for(user)

--- a/app/views/data_sets/edit.html.erb
+++ b/app/views/data_sets/edit.html.erb
@@ -1,7 +1,10 @@
 <div class="w-full">
   <%= render 'shared/header',
     title: "Edit #{@data_set.title}",
-    description: "Make updates to this existing dataset.  Note: file updates will be added shortly."
+    description: "Make updates to this existing dataset.  Note: file updates will be added shortly.",
+    buttons: [
+      { label: "Edit Mappings", href: map_data_set_path(@data_set) }
+    ]
   %>
   <div class="responsive-container">
     <div class="my-12 px-4 py-5 sm:px-6">

--- a/app/views/data_sets/index.html.erb
+++ b/app/views/data_sets/index.html.erb
@@ -50,6 +50,11 @@
                           <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                         </svg>
                       <% end %>
+                      <%= link_to map_data_set_path(data_set), class: 'inline-block', title: 'Edit Dataset' do %>
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                        </svg>
+                      <% end %>
                       <%= link_to data_set_path(data_set), class: 'inline-block ml-1', title: 'Delete Dataset', data: {"turbo-confirm": "Are you sure you want to delete this data set?", "turbo-method": :delete } do %>
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/app/views/data_sets/map.html.erb
+++ b/app/views/data_sets/map.html.erb
@@ -46,7 +46,18 @@
                           <%= field.empty_value_count %>
                         </td>
                         <td>
-                          <%= form.select "common_types[#{position}]", options_for_select(Field::TYPES, field.common_type), {}, { class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" } %>
+                          <%= form.select "common_types[#{position}]",
+                              options_for_select(
+                                Field::TYPES,
+                                selected: field.common_type,
+                                disabled: @classified_fields
+                              ),
+                              {},
+                              {
+                                class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full",
+                                disabled: field.classified?
+                              }
+                          %>
                         </td>
                       </tr>
                     <% end %>

--- a/app/views/data_sets/show.html.erb
+++ b/app/views/data_sets/show.html.erb
@@ -4,6 +4,7 @@
     description: @data_set.description,
     buttons: [
       { label: "Edit", href: edit_data_set_path(@data_set) },
+      { label: "Edit Mappings", href: map_data_set_path(@data_set) },
       { label: "List Datasets", href: data_sets_path, class: "button-secondary" }
     ]
   %>

--- a/spec/features/data_sets/create_data_set_spec.rb
+++ b/spec/features/data_sets/create_data_set_spec.rb
@@ -45,4 +45,93 @@ RSpec.describe "Create a data set", type: :feature do
       expect(data_set.fields.where.not(common_type: nil).count).to eq(3)
     end
   end
+
+  context "when modifying mappings" do
+    let(:data_set) do
+      create(:data_set, files: [
+               Rack::Test::UploadedFile.new("spec/support/files/police-incidents-2022.csv", "text/csv"),
+             ])
+    end
+
+    let(:call_type) { data_set.fields.find_by(heading: "call_type") }
+    let(:incident_number) { data_set.fields.find_by(heading: "incident_number") }
+    let(:call_type_group) { data_set.fields.find_by(heading: "call_type_group") }
+
+    before do
+      data_set.prepare_datamap
+
+      call_type.update(common_type: "Detailed Call Type")
+
+      # Oops, we mapped call_type_group and incident_number to the wrong types!
+      incident_number.update(common_type: "Emergency Category")
+      call_type_group.update(common_type: "Priority")
+
+      data_set.reload.analyze!
+    end
+
+    it "re-maps all fields except the classified ones" do
+      create(:classification, unique_value: data_set.call_type_field.unique_values.first)
+
+      original_call_type_group_ids = call_type_group.unique_values.map(&:id)
+
+      expect(call_type_group.unique_values.map(&:value)).to eq(
+        ["Public Service", "Motor Vehicle", "Quality of Life", "Other"],
+      )
+
+      sign_in user
+      visit root_path
+      find("#sidenav").click_on "Datasets"
+
+      find(:xpath, "//a[@href='/data_sets/#{data_set.slug}/map']", match: :first).click
+
+      expect(page).to have_content("Map Data Fields")
+
+      # Current mappings are pre-selected, classified ones are disabled
+      expect(page).to have_select(
+        "data_set[common_types[0]]",
+        selected: "Emergency Category",
+      )
+
+      expect(page).to have_select(
+        "data_set_common_types[1]",
+        selected: "Detailed Call Type",
+        disabled: true,
+      )
+
+      expect(page).to have_select(
+        "data_set[common_types[2]]",
+        selected: "Priority",
+      )
+
+      # Options for classified fields is disabled
+      within("#data_set_common_types\\[2\\]") do
+        expect(find("option[value='Detailed Call Type'][@disabled]")).to be_present
+      end
+
+      # Replace the wrong incident_number and call_type_group mappings
+      select "", from: "data_set_common_types[0]"
+      select "Call Category", from: "data_set_common_types[2]"
+
+      click_on "Map Data Fields"
+      expect(page).to have_content("Fields were successfully mapped.")
+
+      data_set.reload
+      call_type.reload
+      incident_number.reload
+      call_type_group.reload
+
+      expect(incident_number.common_type).to be_nil
+      expect(call_type_group.common_type).to eq("Call Category")
+
+      # All unique values for the incident_number have been deleted
+      # since its mapping was removed
+      expect(incident_number.unique_values).to eq([])
+
+      # The call type group unique values remain the same
+      expect(call_type_group.unique_values.map(&:id)).to eq(original_call_type_group_ids)
+
+      # The classified field was not modified
+      expect(call_type.common_type).to eq("Detailed Call Type")
+    end
+  end
 end


### PR DESCRIPTION
## Overview

Add the ability to re-map non-classified data set fields by displaying links to the mapping page and adjusting the mapping & analysis logic.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Related tickets

Fixes #88

## Changes

- Add links to the mapping page on the data set index page, show page, and edit page.
- Adjusted the mapping logic to allow the re-mapping of fields without any classification.
- Disable the mapping selection for fields that have classifications and disable the options mapped to classified fields for all other fields.
- Allow a data set to be analyzed more than  once (with a check to avoid re-analyzing the same fields)
- Destroy all `unique_values` if the new `common_type` is not of interest (i.e. not part of `Field::VALUE_TYPES`)

## Notes

![disabled](https://user-images.githubusercontent.com/2647689/189332225-2e64e18e-ad8c-4cdc-a4a4-98770efa6660.PNG)
