### PR TITLE
#107: Fixed some escaping issues when generating examples.

### DIFF
--- a/app/models/unique_value.rb
+++ b/app/models/unique_value.rb
@@ -57,8 +57,8 @@ class UniqueValue < ApplicationRecord
     tail = "| tail -n +2 | "
 
     field.data_set.datafile.with_file do |f|
-      data = `sed -E 's/("([^"]*)")?,/\2\t/g' #{f.path} #{tail} grep "#{value&.shellescape}" | head -5`
-      &.split("\n")&.map do |line|
+      result = `sed -E 's/("([^"]*)")?,/\\2\\t/g' #{f.path} #{tail} grep #{value&.shellescape} | head -5`
+      data = result&.split("\n")&.map do |line|
         line.delete("\u0002").delete("\r").split("\t")
       end
     end

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -251,6 +251,7 @@ RSpec.describe DataSet, type: :model do
                                                "Intoxication",
                                                "Mental Health Issue",
                                                "Trespass",
+                                               "BURGLAR ALARM, SILENT",
                                              ]))
       end
     end

--- a/spec/support/files/police-incidents-2022.csv
+++ b/spec/support/files/police-incidents-2022.csv
@@ -5,3 +5,4 @@ incident_number,call_type,call_type_group,call_time,Street,call_origin,mental_he
 22BU000007,Intoxication,Quality of Life,2021-12-31T21:25:52-05:00,Main St,Phone,0,0,0,1,D,Downtown,44.4756491602608,-73.2145682567682,2 am,Saturday,3,Central,Priority 3,January,2022
 22BU000013,Mental Health Issue,Public Service,2022-01-01T00:20:29-05:00,S Champlain St,Phone,1,0,0,0,E,SouthEnd,44.4725442759697,-73.2166263378627,5 am,Saturday,5,South,Priority 2,January,2022
 22BU000016,Trespass,Other,2022-01-01T04:37:29-05:00,Pine St,Phone,0,0,0,0,D,Downtown,44.4742771510042,-73.2156656366762,9 am,Saturday,5,South,Priority 2,January,2022
+22BU000019,"BURGLAR ALARM, SILENT",Other,2022-01-01T04:41:18-05:00,Pit St,Phone,0,0,0,0,D,Downtown,44.4742771510042,-73.2156656366762,9 am,Saturday,5,South,Priority 2,January,2022


### PR DESCRIPTION
## Overview

Addresses issues with generating examples for some codes when the code included characters that had been escaped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

Fixes #107

## Changes

- Removed quotes around escaped value
- Added missing escape characters before slashes

## Notes


