### PR TITLE
#109: Update example generation to use the csv gem.

### DIFF
--- a/spec/factories/data_set_factory.rb
+++ b/spec/factories/data_set_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:data_set) do
     title { Faker::Lorem.word }
-    files { [Rack::Test::UploadedFile.new("spec/support/files/test.pdf", "application/pdf")] }
+    files { [Rack::Test::UploadedFile.new("spec/support/files/police-incidents-2022.csv", "text/csv")] }
   end
 end


### PR DESCRIPTION
## Overview

This addresses an issue where `sed` is inexact and will match rows where the call type value can be found in any column. This also reduces the time to generate examples slightly.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related tickets

Fixes #109

## Changes

- Update example generation to use the csv gem.

## Notes


